### PR TITLE
Add new method GetState and storage of RRN response attribute

### DIFF
--- a/src/GuzzleHttp/GuzzleHttpOptionsBag.php
+++ b/src/GuzzleHttp/GuzzleHttpOptionsBag.php
@@ -72,8 +72,6 @@ final class GuzzleHttpOptionsBag
 
     /**
      * Assert that client options are correct.
-     *
-     * @param array $options
      */
     private function assertOptions(array $options): void
     {
@@ -86,10 +84,6 @@ final class GuzzleHttpOptionsBag
 
     /**
      * Assert that fields include only valid.
-     *
-     * @param array $fields
-     * @param array $validFields
-     * @param string $message
      */
     private function assertValidFields(array $fields, array $validFields, string $message): void
     {
@@ -102,8 +96,6 @@ final class GuzzleHttpOptionsBag
 
     /**
      * Assert that options per operations have correct options and operations.
-     *
-     * @param array $optionsPerOperation
      */
     private function assertOptionsPerOperation(array $optionsPerOperation): void
     {

--- a/src/GuzzleHttp/GuzzleHttpOptionsBag.php
+++ b/src/GuzzleHttp/GuzzleHttpOptionsBag.php
@@ -72,6 +72,8 @@ final class GuzzleHttpOptionsBag
 
     /**
      * Assert that client options are correct.
+     *
+     * @param array $options
      */
     private function assertOptions(array $options): void
     {
@@ -84,6 +86,10 @@ final class GuzzleHttpOptionsBag
 
     /**
      * Assert that fields include only valid.
+     *
+     * @param array $fields
+     * @param array $validFields
+     * @param string $message
      */
     private function assertValidFields(array $fields, array $validFields, string $message): void
     {
@@ -96,6 +102,8 @@ final class GuzzleHttpOptionsBag
 
     /**
      * Assert that options per operations have correct options and operations.
+     *
+     * @param array $optionsPerOperation
      */
     private function assertOptionsPerOperation(array $optionsPerOperation): void
     {

--- a/src/GuzzleHttp/GuzzleHttpPaytureTransport.php
+++ b/src/GuzzleHttp/GuzzleHttpPaytureTransport.php
@@ -28,7 +28,10 @@ final class GuzzleHttpPaytureTransport implements TransportInterface
     private $optionsBag;
 
     /**
+     * @param ClientInterface $client
+     * @param TerminalConfiguration $config
      * @param GuzzleHttpOptionsBag $optionsBag
+     * @param LoggerInterface|null $logger
      */
     public function __construct(
         ClientInterface $client,

--- a/src/GuzzleHttp/GuzzleHttpPaytureTransport.php
+++ b/src/GuzzleHttp/GuzzleHttpPaytureTransport.php
@@ -28,10 +28,7 @@ final class GuzzleHttpPaytureTransport implements TransportInterface
     private $optionsBag;
 
     /**
-     * @param ClientInterface $client
-     * @param TerminalConfiguration $config
      * @param GuzzleHttpOptionsBag $optionsBag
-     * @param LoggerInterface|null $logger
      */
     public function __construct(
         ClientInterface $client,

--- a/src/PaytureInPayTerminal.php
+++ b/src/PaytureInPayTerminal.php
@@ -37,12 +37,16 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
     /**
      * @see https://payture.com/api#inpay_init_
      *
+     * @param SessionType $sessionType
      * @param string $orderId Payment ID in Merchant system
+     * @param string $product
      * @param int $amount Payment amount
      * @param string $clientIp User IP address
      * @param string $url back URL
      * @param string $templateTag Used template tag. If empty string - no template tag will be passed
      * @param array $extra Payture none requirement extra fields
+     *
+     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -87,6 +91,8 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Charging amount in kopecks
      *
+     * @return TerminalResponse
+     *
      * @throws TransportException
      */
     public function charge(string $orderId, int $amount): TerminalResponse
@@ -108,6 +114,8 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
      *
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Amount in kopecks that is to be returned
+     *
+     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -131,6 +139,8 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Amount in kopecks that is to be returned
      *
+     * @return TerminalResponse
+     *
      * @throws TransportException
      */
     public function refund(string $orderId, int $amount): TerminalResponse
@@ -148,9 +158,12 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
     /**
      * @deprecated
      * @see PaytureInPayTerminalInterface::getState()
+     *
      * @see https://payture.com/api#inpay_paystatus_
      *
      * @param string $orderId Payment ID in Merchant system
+     *
+     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -165,11 +178,13 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
     }
 
     /**
-     * Returns actual order state.
+     * Returns actual order state
      *
      * @see https://payture.com/api/#inpay_getstate_
      *
      * @param string $orderId Payment ID in Merchant system
+     *
+     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -193,6 +208,11 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
     }
 
     /**
+     * @param PaytureOperation $operation
+     * @param array $parameters
+     *
+     * @return TerminalResponse
+     *
      * @throws TransportException
      */
     private function sendRequest(PaytureOperation $operation, array $parameters): TerminalResponse

--- a/src/PaytureInPayTerminal.php
+++ b/src/PaytureInPayTerminal.php
@@ -37,16 +37,12 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
     /**
      * @see https://payture.com/api#inpay_init_
      *
-     * @param SessionType $sessionType
      * @param string $orderId Payment ID in Merchant system
-     * @param string $product
      * @param int $amount Payment amount
      * @param string $clientIp User IP address
      * @param string $url back URL
      * @param string $templateTag Used template tag. If empty string - no template tag will be passed
      * @param array $extra Payture none requirement extra fields
-     *
-     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -91,8 +87,6 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Charging amount in kopecks
      *
-     * @return TerminalResponse
-     *
      * @throws TransportException
      */
     public function charge(string $orderId, int $amount): TerminalResponse
@@ -114,8 +108,6 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
      *
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Amount in kopecks that is to be returned
-     *
-     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -139,8 +131,6 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Amount in kopecks that is to be returned
      *
-     * @return TerminalResponse
-     *
      * @throws TransportException
      */
     public function refund(string $orderId, int $amount): TerminalResponse
@@ -158,12 +148,9 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
     /**
      * @deprecated
      * @see PaytureInPayTerminalInterface::getState()
-     *
      * @see https://payture.com/api#inpay_paystatus_
      *
      * @param string $orderId Payment ID in Merchant system
-     *
-     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -178,13 +165,11 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
     }
 
     /**
-     * Returns actual order state
+     * Returns actual order state.
      *
      * @see https://payture.com/api/#inpay_getstate_
      *
      * @param string $orderId Payment ID in Merchant system
-     *
-     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -208,11 +193,6 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
     }
 
     /**
-     * @param PaytureOperation $operation
-     * @param array $parameters
-     *
-     * @return TerminalResponse
-     *
      * @throws TransportException
      */
     private function sendRequest(PaytureOperation $operation, array $parameters): TerminalResponse

--- a/src/PaytureInPayTerminal.php
+++ b/src/PaytureInPayTerminal.php
@@ -156,7 +156,8 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
     }
 
     /**
-     * Get status of the last deal for the OrderId.
+     * @deprecated
+     * @see PaytureInPayTerminalInterface::getState()
      *
      * @see https://payture.com/api#inpay_paystatus_
      *
@@ -174,6 +175,27 @@ final class PaytureInPayTerminal implements PaytureInPayTerminalInterface
         ];
 
         return $this->sendRequest(PaytureOperation::PAY_STATUS(), $data);
+    }
+
+    /**
+     * Returns actual order state
+     *
+     * @see https://payture.com/api/#inpay_getstate_
+     *
+     * @param string $orderId Payment ID in Merchant system
+     *
+     * @return TerminalResponse
+     *
+     * @throws TransportException
+     */
+    public function getState(string $orderId): TerminalResponse
+    {
+        $data = [
+            'Key' => $this->config->getKey(),
+            'OrderId' => $orderId,
+        ];
+
+        return $this->sendRequest(PaytureOperation::GET_STATE(), $data);
     }
 
     public function createPaymentUrl(string $sessionId): string

--- a/src/PaytureInPayTerminalInterface.php
+++ b/src/PaytureInPayTerminalInterface.php
@@ -10,20 +10,15 @@ interface PaytureInPayTerminalInterface
      * @see https://payture.com/api/#inpay_getstate_
      *
      * @param string $orderId Payment ID in Merchant system
-     *
-     * @return TerminalResponse
      */
     public function getState(string $orderId): TerminalResponse;
 
     /**
      * @deprecated
      * @see PaytureInPayTerminalInterface::getState()
-     *
      * @see https://payture.com/api#inpay_paystatus_
      *
      * @param string $orderId Payment ID in Merchant system
-     *
-     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -32,16 +27,12 @@ interface PaytureInPayTerminalInterface
     /**
      * @see https://payture.com/api#inpay_init_
      *
-     * @param SessionType $sessionType
      * @param string $orderId Payment ID in Merchant system
-     * @param string $product
      * @param int $amount Payment amount
      * @param string $clientIp User IP address
      * @param string $url back URL
      * @param string $templateTag Used template tag. If empty string - no template tag will be passed
      * @param array $extra Payture none requirement extra fields
-     *
-     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -56,11 +47,6 @@ interface PaytureInPayTerminalInterface
         array $extra = []
     ): TerminalResponse;
 
-    /**
-     * @param string $sessionId
-     *
-     * @return string
-     */
     public function createPaymentUrl(string $sessionId): string;
 
     /**
@@ -68,8 +54,6 @@ interface PaytureInPayTerminalInterface
      *
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Amount in kopecks that is to be returned
-     *
-     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -80,8 +64,6 @@ interface PaytureInPayTerminalInterface
      *
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Charging amount in kopecks
-     *
-     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -94,8 +76,6 @@ interface PaytureInPayTerminalInterface
      *
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Amount in kopecks that is to be returned
-     *
-     * @return TerminalResponse
      *
      * @throws TransportException
      */

--- a/src/PaytureInPayTerminalInterface.php
+++ b/src/PaytureInPayTerminalInterface.php
@@ -10,15 +10,20 @@ interface PaytureInPayTerminalInterface
      * @see https://payture.com/api/#inpay_getstate_
      *
      * @param string $orderId Payment ID in Merchant system
+     *
+     * @return TerminalResponse
      */
     public function getState(string $orderId): TerminalResponse;
 
     /**
      * @deprecated
      * @see PaytureInPayTerminalInterface::getState()
+     *
      * @see https://payture.com/api#inpay_paystatus_
      *
      * @param string $orderId Payment ID in Merchant system
+     *
+     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -27,12 +32,16 @@ interface PaytureInPayTerminalInterface
     /**
      * @see https://payture.com/api#inpay_init_
      *
+     * @param SessionType $sessionType
      * @param string $orderId Payment ID in Merchant system
+     * @param string $product
      * @param int $amount Payment amount
      * @param string $clientIp User IP address
      * @param string $url back URL
      * @param string $templateTag Used template tag. If empty string - no template tag will be passed
      * @param array $extra Payture none requirement extra fields
+     *
+     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -47,6 +56,11 @@ interface PaytureInPayTerminalInterface
         array $extra = []
     ): TerminalResponse;
 
+    /**
+     * @param string $sessionId
+     *
+     * @return string
+     */
     public function createPaymentUrl(string $sessionId): string;
 
     /**
@@ -54,6 +68,8 @@ interface PaytureInPayTerminalInterface
      *
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Amount in kopecks that is to be returned
+     *
+     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -64,6 +80,8 @@ interface PaytureInPayTerminalInterface
      *
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Charging amount in kopecks
+     *
+     * @return TerminalResponse
      *
      * @throws TransportException
      */
@@ -76,6 +94,8 @@ interface PaytureInPayTerminalInterface
      *
      * @param string $orderId Payment ID in Merchant system
      * @param int $amount Amount in kopecks that is to be returned
+     *
+     * @return TerminalResponse
      *
      * @throws TransportException
      */

--- a/src/PaytureInPayTerminalInterface.php
+++ b/src/PaytureInPayTerminalInterface.php
@@ -7,6 +7,18 @@ use Lamoda\Payture\InPayClient\Exception\TransportException;
 interface PaytureInPayTerminalInterface
 {
     /**
+     * @see https://payture.com/api/#inpay_getstate_
+     *
+     * @param string $orderId Payment ID in Merchant system
+     *
+     * @return TerminalResponse
+     */
+    public function getState(string $orderId): TerminalResponse;
+
+    /**
+     * @deprecated
+     * @see PaytureInPayTerminalInterface::getState()
+     *
      * @see https://payture.com/api#inpay_paystatus_
      *
      * @param string $orderId Payment ID in Merchant system

--- a/src/PaytureOperation.php
+++ b/src/PaytureOperation.php
@@ -13,6 +13,7 @@ use Paillechat\Enum\Enum;
  * @method static static UNBLOCK()
  * @method static static REFUND()
  * @method static static PAY_STATUS()
+ * @method static static GET_STATE()
  *
  * @internal
  */
@@ -23,7 +24,12 @@ final class PaytureOperation extends Enum
     public const CHARGE = 'Charge';
     public const UNBLOCK = 'Unblock';
     public const REFUND = 'Refund';
+    /**
+     * @deprecated
+     * @see PaytureOperation::GET_STATE
+     */
     public const PAY_STATUS = 'PayStatus';
+    public const GET_STATE = 'GetState';
 
     public function __toString(): string
     {

--- a/src/TerminalConfiguration.php
+++ b/src/TerminalConfiguration.php
@@ -61,24 +61,12 @@ final class TerminalConfiguration
         return $this->password;
     }
 
-    /**
-     * @param PaytureOperation $operation
-     * @param string $interface
-     * @param array $parameters
-     *
-     * @return string
-     */
     public function buildOperationUrl(PaytureOperation $operation, string $interface, array $parameters): string
     {
         return $this->getUrl() . $interface .
             '/' . self::mapOperationToPath($operation) . '?' . http_build_query($parameters);
     }
 
-    /**
-     * @param string $url
-     *
-     * @return string
-     */
     public function normalizeUrl(string $url): string
     {
         return rtrim($url, '/') . '/';

--- a/src/TerminalConfiguration.php
+++ b/src/TerminalConfiguration.php
@@ -37,6 +37,8 @@ final class TerminalConfiguration
                 return 'Refund';
             case (string) PaytureOperation::PAY_STATUS():
                 return 'PayStatus';
+            case (string) PaytureOperation::GET_STATE():
+                return 'GetState';
         }
 
         // @codeCoverageIgnoreStart

--- a/src/TerminalConfiguration.php
+++ b/src/TerminalConfiguration.php
@@ -61,12 +61,24 @@ final class TerminalConfiguration
         return $this->password;
     }
 
+    /**
+     * @param PaytureOperation $operation
+     * @param string $interface
+     * @param array $parameters
+     *
+     * @return string
+     */
     public function buildOperationUrl(PaytureOperation $operation, string $interface, array $parameters): string
     {
         return $this->getUrl() . $interface .
             '/' . self::mapOperationToPath($operation) . '?' . http_build_query($parameters);
     }
 
+    /**
+     * @param string $url
+     *
+     * @return string
+     */
     public function normalizeUrl(string $url): string
     {
         return rtrim($url, '/') . '/';

--- a/src/TerminalResponse.php
+++ b/src/TerminalResponse.php
@@ -69,7 +69,7 @@ final class TerminalResponse
     private $sessionId = '';
 
     /**
-     * Unique transaction number assigned by the acquiring bank
+     * Unique transaction number assigned by the acquiring bank.
      *
      * @var string|null
      */
@@ -91,9 +91,6 @@ final class TerminalResponse
         $this->orderId = $orderId;
     }
 
-    /**
-     * @return bool
-     */
     public function isSuccess(): bool
     {
         return $this->success;

--- a/src/TerminalResponse.php
+++ b/src/TerminalResponse.php
@@ -69,7 +69,7 @@ final class TerminalResponse
     private $sessionId = '';
 
     /**
-     * Unique transaction number assigned by the acquiring bank.
+     * Unique transaction number assigned by the acquiring bank
      *
      * @var string|null
      */
@@ -91,6 +91,9 @@ final class TerminalResponse
         $this->orderId = $orderId;
     }
 
+    /**
+     * @return bool
+     */
     public function isSuccess(): bool
     {
         return $this->success;

--- a/src/TerminalResponse.php
+++ b/src/TerminalResponse.php
@@ -68,6 +68,13 @@ final class TerminalResponse
      */
     private $sessionId = '';
 
+    /**
+     * Unique transaction number assigned by the acquiring bank
+     *
+     * @var string|null
+     */
+    private $rrn;
+
     /** Error code.
      *
      * @var string
@@ -107,6 +114,11 @@ final class TerminalResponse
         $this->amount = $amount;
     }
 
+    public function getRrn(): ?string
+    {
+        return $this->rrn;
+    }
+
     public function getSessionId(): string
     {
         return $this->sessionId;
@@ -143,6 +155,11 @@ final class TerminalResponse
     public function setState(string $state): void
     {
         $this->state = $state;
+    }
+
+    public function setRrn(string $rrn): void
+    {
+        $this->rrn = $rrn;
     }
 
     public function isNewState(): bool

--- a/src/TerminalResponseBuilder.php
+++ b/src/TerminalResponseBuilder.php
@@ -49,6 +49,10 @@ final class TerminalResponseBuilder
             $result->setErrorCode($attributes['ErrCode']);
         }
 
+        if (isset($attributes['RRN'])) {
+            $result->setRrn($attributes['RRN']);
+        }
+
         return $result;
     }
 
@@ -96,6 +100,8 @@ final class TerminalResponseBuilder
                 return 'Refund';
             case (string) PaytureOperation::PAY_STATUS():
                 return 'PayStatus';
+            case (string) PaytureOperation::GET_STATE():
+                return 'GetState';
         }
 
         //@codeCoverageIgnoreStart

--- a/src/TerminalResponseBuilder.php
+++ b/src/TerminalResponseBuilder.php
@@ -10,6 +10,11 @@ use Lamoda\Payture\InPayClient\Exception\InvalidResponseException;
 final class TerminalResponseBuilder
 {
     /**
+     * @param string $transportResponse
+     * @param PaytureOperation $operation
+     *
+     * @return TerminalResponse
+     *
      * @throws InvalidResponseException
      */
     public static function parseTransportResponse(
@@ -52,6 +57,11 @@ final class TerminalResponseBuilder
     }
 
     /**
+     * @param string $xml
+     * @param string $operation
+     *
+     * @return array
+     *
      * @throws InvalidResponseException
      */
     private static function parseAttributesFromXmlResponse(string $xml, string $operation): array

--- a/src/TerminalResponseBuilder.php
+++ b/src/TerminalResponseBuilder.php
@@ -10,11 +10,6 @@ use Lamoda\Payture\InPayClient\Exception\InvalidResponseException;
 final class TerminalResponseBuilder
 {
     /**
-     * @param string $transportResponse
-     * @param PaytureOperation $operation
-     *
-     * @return TerminalResponse
-     *
      * @throws InvalidResponseException
      */
     public static function parseTransportResponse(
@@ -57,11 +52,6 @@ final class TerminalResponseBuilder
     }
 
     /**
-     * @param string $xml
-     * @param string $operation
-     *
-     * @return array
-     *
      * @throws InvalidResponseException
      */
     private static function parseAttributesFromXmlResponse(string $xml, string $operation): array

--- a/src/TestUtils/PaymentHelper.php
+++ b/src/TestUtils/PaymentHelper.php
@@ -42,7 +42,6 @@ final class PaymentHelper extends Assert
     }
 
     /**
-     * @param ResponseInterface $response
      * @param string[] $names
      *
      * @return string[]
@@ -68,12 +67,6 @@ final class PaymentHelper extends Assert
     }
 
     /**
-     * @param string $orderNr
-     * @param int $amount
-     * @param string $paymentUrl
-     * @param Card $card
-     * @param string $sandboxUrl
-     *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function pay(
@@ -98,10 +91,6 @@ final class PaymentHelper extends Assert
     }
 
     /**
-     * @param string $paymentUrl
-     * @param string $sandboxUrl
-     * @param array $data
-     *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     private function sendPayment(string $paymentUrl, string $sandboxUrl, array $data): void

--- a/src/TestUtils/PaymentHelper.php
+++ b/src/TestUtils/PaymentHelper.php
@@ -42,6 +42,7 @@ final class PaymentHelper extends Assert
     }
 
     /**
+     * @param ResponseInterface $response
      * @param string[] $names
      *
      * @return string[]
@@ -67,6 +68,12 @@ final class PaymentHelper extends Assert
     }
 
     /**
+     * @param string $orderNr
+     * @param int $amount
+     * @param string $paymentUrl
+     * @param Card $card
+     * @param string $sandboxUrl
+     *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function pay(
@@ -91,6 +98,10 @@ final class PaymentHelper extends Assert
     }
 
     /**
+     * @param string $paymentUrl
+     * @param string $sandboxUrl
+     * @param array $data
+     *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     private function sendPayment(string $paymentUrl, string $sandboxUrl, array $data): void

--- a/src/TransportInterface.php
+++ b/src/TransportInterface.php
@@ -7,6 +7,12 @@ use Lamoda\Payture\InPayClient\Exception\TransportException;
 interface TransportInterface
 {
     /**
+     * @param PaytureOperation $operation
+     * @param string $interface
+     * @param array $parameters
+     *
+     * @return string
+     *
      * @throws TransportException
      */
     public function request(PaytureOperation $operation, string $interface, array $parameters): string;

--- a/src/TransportInterface.php
+++ b/src/TransportInterface.php
@@ -7,12 +7,6 @@ use Lamoda\Payture\InPayClient\Exception\TransportException;
 interface TransportInterface
 {
     /**
-     * @param PaytureOperation $operation
-     * @param string $interface
-     * @param array $parameters
-     *
-     * @return string
-     *
      * @throws TransportException
      */
     public function request(PaytureOperation $operation, string $interface, array $parameters): string;

--- a/tests/EndToEnd/AbstractTerminalTestCase.php
+++ b/tests/EndToEnd/AbstractTerminalTestCase.php
@@ -37,6 +37,8 @@ abstract class AbstractTerminalTestCase extends TestCase
      * Successful payment without 3DS and with optional CVV.
      *
      * @see https://payture.com/api#test-cards_
+     *
+     * @return Card
      */
     private static function getTestCard(): Card
     {

--- a/tests/EndToEnd/AbstractTerminalTestCase.php
+++ b/tests/EndToEnd/AbstractTerminalTestCase.php
@@ -37,8 +37,6 @@ abstract class AbstractTerminalTestCase extends TestCase
      * Successful payment without 3DS and with optional CVV.
      *
      * @see https://payture.com/api#test-cards_
-     *
-     * @return Card
      */
     private static function getTestCard(): Card
     {

--- a/tests/EndToEnd/TwoStepPaymentTerminalTest.php
+++ b/tests/EndToEnd/TwoStepPaymentTerminalTest.php
@@ -3,6 +3,7 @@
 namespace Lamoda\Payture\InPayClient\Tests\EndToEnd;
 
 use Lamoda\Payture\InPayClient\SessionType;
+use Lamoda\Payture\InPayClient\TerminalResponse;
 
 /**
  * @coversNothing
@@ -11,11 +12,67 @@ final class TwoStepPaymentTerminalTest extends AbstractTerminalTestCase
 {
     private const ORDER_PRICE = 10000;
 
+    /**
+     * Keep the test suite with deprecated payStatus
+     */
+    public function testPaytureInPayApiWithPayStatus(): void
+    {
+        $orderId = self::generateOrderId();
+
+        $response = $this->initPayment($orderId);
+        $sessionId = $response->getSessionId();
+
+        $response = $this->getTerminal()->payStatus($orderId);
+        self::assertTrue($response->isSuccess());
+
+        $url = $this->getTerminal()->createPaymentUrl($sessionId);
+
+        $this->pay($url, $orderId, self::ORDER_PRICE);
+        $response = $this->getTerminal()->payStatus($orderId);
+        self::assertTrue($response->isAuthorizedState());
+
+        $response = $this->getTerminal()->charge($orderId, self::ORDER_PRICE);
+        self::assertTrue($response->isSuccess());
+        $response = $this->getTerminal()->payStatus($orderId);
+        self::assertTrue($response->isChargedState());
+
+        $response = $this->getTerminal()->refund($orderId, self::ORDER_PRICE);
+        self::assertTrue($response->isSuccess());
+        $response = $this->getTerminal()->payStatus($orderId);
+        self::assertTrue($response->isRefundedState());
+        self::assertNotEmpty($response->getRrn());
+    }
+
     public function testPaytureInPayApi(): void
     {
         $orderId = self::generateOrderId();
 
-        $response = $this->getTerminal()->init(
+        $response = $this->initPayment($orderId);
+        $sessionId = $response->getSessionId();
+
+        $url = $this->getTerminal()->createPaymentUrl($sessionId);
+
+        $this->pay($url, $orderId, self::ORDER_PRICE);
+        $response = $this->getTerminal()->getState($orderId);
+        self::assertNotEmpty($response->getRrn());
+        self::assertTrue($response->isAuthorizedState());
+
+        $response = $this->getTerminal()->charge($orderId, self::ORDER_PRICE);
+        self::assertTrue($response->isSuccess());
+        $response = $this->getTerminal()->getState($orderId);
+        self::assertTrue($response->isChargedState());
+        self::assertNotEmpty($response->getRrn());
+
+        $response = $this->getTerminal()->refund($orderId, self::ORDER_PRICE);
+        self::assertTrue($response->isSuccess());
+        $response = $this->getTerminal()->getState($orderId);
+        self::assertTrue($response->isRefundedState());
+        self::assertNotEmpty($response->getRrn());
+    }
+
+    private function initPayment(string $orderId): TerminalResponse
+    {
+        return $this->getTerminal()->init(
             SessionType::BLOCK(),
             $orderId,
             'Auto Test purchase',
@@ -23,25 +80,5 @@ final class TwoStepPaymentTerminalTest extends AbstractTerminalTestCase
             '127.0.0.1',
             'https://github.com/lamoda'
         );
-        $sessionId = $response->getSessionId();
-
-        $response = $this->getTerminal()->getState($orderId);
-        self::assertTrue($response->isSuccess());
-
-        $url = $this->getTerminal()->createPaymentUrl($sessionId);
-
-        $this->pay($url, $orderId, self::ORDER_PRICE);
-        $response = $this->getTerminal()->getState($orderId);
-        self::assertTrue($response->isAuthorizedState());
-
-        $response = $this->getTerminal()->charge($orderId, self::ORDER_PRICE);
-        self::assertTrue($response->isSuccess());
-        $response = $this->getTerminal()->getState($orderId);
-        self::assertTrue($response->isChargedState());
-
-        $response = $this->getTerminal()->refund($orderId, self::ORDER_PRICE);
-        self::assertTrue($response->isSuccess());
-        $response = $this->getTerminal()->getState($orderId);
-        self::assertTrue($response->isRefundedState());
     }
 }

--- a/tests/EndToEnd/TwoStepPaymentTerminalTest.php
+++ b/tests/EndToEnd/TwoStepPaymentTerminalTest.php
@@ -13,7 +13,7 @@ final class TwoStepPaymentTerminalTest extends AbstractTerminalTestCase
     private const ORDER_PRICE = 10000;
 
     /**
-     * Keep the test suite with deprecated payStatus.
+     * Keep the test suite with deprecated payStatus
      */
     public function testPaytureInPayApiWithPayStatus(): void
     {

--- a/tests/EndToEnd/TwoStepPaymentTerminalTest.php
+++ b/tests/EndToEnd/TwoStepPaymentTerminalTest.php
@@ -25,23 +25,23 @@ final class TwoStepPaymentTerminalTest extends AbstractTerminalTestCase
         );
         $sessionId = $response->getSessionId();
 
-        $response = $this->getTerminal()->payStatus($orderId);
+        $response = $this->getTerminal()->getState($orderId);
         self::assertTrue($response->isSuccess());
 
         $url = $this->getTerminal()->createPaymentUrl($sessionId);
 
         $this->pay($url, $orderId, self::ORDER_PRICE);
-        $response = $this->getTerminal()->payStatus($orderId);
+        $response = $this->getTerminal()->getState($orderId);
         self::assertTrue($response->isAuthorizedState());
 
         $response = $this->getTerminal()->charge($orderId, self::ORDER_PRICE);
         self::assertTrue($response->isSuccess());
-        $response = $this->getTerminal()->payStatus($orderId);
+        $response = $this->getTerminal()->getState($orderId);
         self::assertTrue($response->isChargedState());
 
         $response = $this->getTerminal()->refund($orderId, self::ORDER_PRICE);
         self::assertTrue($response->isSuccess());
-        $response = $this->getTerminal()->payStatus($orderId);
+        $response = $this->getTerminal()->getState($orderId);
         self::assertTrue($response->isRefundedState());
     }
 }

--- a/tests/EndToEnd/TwoStepPaymentTerminalTest.php
+++ b/tests/EndToEnd/TwoStepPaymentTerminalTest.php
@@ -13,7 +13,7 @@ final class TwoStepPaymentTerminalTest extends AbstractTerminalTestCase
     private const ORDER_PRICE = 10000;
 
     /**
-     * Keep the test suite with deprecated payStatus
+     * Keep the test suite with deprecated payStatus.
      */
     public function testPaytureInPayApiWithPayStatus(): void
     {

--- a/tests/Unit/PaytureInPayTerminalTest.php
+++ b/tests/Unit/PaytureInPayTerminalTest.php
@@ -23,9 +23,6 @@ final class PaytureInPayTerminalTest extends TestCase
     /**
      * @dataProvider getInitSessionTypes
      *
-     * @param SessionType $type
-     * @param string $data
-     *
      * @throws \Lamoda\Payture\InPayClient\Exception\TransportException
      */
     public function testPaymentInit(SessionType $type, string $data): void

--- a/tests/Unit/PaytureInPayTerminalTest.php
+++ b/tests/Unit/PaytureInPayTerminalTest.php
@@ -23,6 +23,9 @@ final class PaytureInPayTerminalTest extends TestCase
     /**
      * @dataProvider getInitSessionTypes
      *
+     * @param SessionType $type
+     * @param string $data
+     *
      * @throws \Lamoda\Payture\InPayClient\Exception\TransportException
      */
     public function testPaymentInit(SessionType $type, string $data): void

--- a/tests/Unit/PaytureInPayTerminalTest.php
+++ b/tests/Unit/PaytureInPayTerminalTest.php
@@ -152,6 +152,30 @@ final class PaytureInPayTerminalTest extends TestCase
         self::assertTrue($response->isChargedState());
     }
 
+    public function testGetState(): void
+    {
+        $rrn = '003770024290';
+        $orderId = 'Order-123';
+        $this->transport->expects($this->once())
+            ->method('request')
+            ->with(
+                PaytureOperation::GET_STATE(),
+                'apim',
+                [
+                    'Key' => 'MerchantKey',
+                    'OrderId' => $orderId,
+                ]
+            )->willReturn('<GetState Success="True" OrderId="' . $orderId . '" State="Refunded"
+                Forwarded="False" MerchantContract="Merchant" Amount="12461" RRN="' . $rrn . '"/>');
+
+        $response = $this->terminal->getState($orderId);
+
+        self::assertTrue($response->isSuccess());
+        self::assertTrue($response->isRefundedState());
+        self::assertEquals($rrn, $response->getRrn());
+        self::assertEquals($orderId, $response->getOrderId());
+    }
+
     public function testCreatingPaymentUrl(): void
     {
         self::assertEquals(

--- a/tests/Unit/TerminalConfigurationTest.php
+++ b/tests/Unit/TerminalConfigurationTest.php
@@ -127,6 +127,11 @@ final class TerminalConfigurationTest extends TestCase
                 ['Key' => 'MerchantKey', 'Data' => 'SomeData'],
                 'https://nowhere.payture.com/apim/PayStatus?Key=MerchantKey&Data=SomeData',
             ],
+            [
+                PaytureOperation::GET_STATE(),
+                ['Key' => 'MerchantKey', 'Data' => 'SomeData'],
+                'https://nowhere.payture.com/apim/GetState?Key=MerchantKey&Data=SomeData',
+            ],
         ];
     }
 }

--- a/tests/Unit/TerminalConfigurationTest.php
+++ b/tests/Unit/TerminalConfigurationTest.php
@@ -24,10 +24,6 @@ final class TerminalConfigurationTest extends TestCase
 
     /**
      * @dataProvider notValidConfigVariants
-     *
-     * @param array $options
-     * @param string $exception
-     * @param string $message
      */
     public function testNotValidConfig(array $options, string $exception, string $message): void
     {
@@ -83,10 +79,6 @@ final class TerminalConfigurationTest extends TestCase
 
     /**
      * @dataProvider getOperationUrlProviders
-     *
-     * @param PaytureOperation $operation
-     * @param array $parameters
-     * @param string $expectedUrl
      */
     public function testBuildingOperationUrl(PaytureOperation $operation, array $parameters, string $expectedUrl): void
     {

--- a/tests/Unit/TerminalConfigurationTest.php
+++ b/tests/Unit/TerminalConfigurationTest.php
@@ -24,6 +24,10 @@ final class TerminalConfigurationTest extends TestCase
 
     /**
      * @dataProvider notValidConfigVariants
+     *
+     * @param array $options
+     * @param string $exception
+     * @param string $message
      */
     public function testNotValidConfig(array $options, string $exception, string $message): void
     {
@@ -79,6 +83,10 @@ final class TerminalConfigurationTest extends TestCase
 
     /**
      * @dataProvider getOperationUrlProviders
+     *
+     * @param PaytureOperation $operation
+     * @param array $parameters
+     * @param string $expectedUrl
      */
     public function testBuildingOperationUrl(PaytureOperation $operation, array $parameters, string $expectedUrl): void
     {

--- a/tests/Unit/TerminalResponseBuilderTest.php
+++ b/tests/Unit/TerminalResponseBuilderTest.php
@@ -73,6 +73,12 @@ final class TerminalResponseBuilderTest extends TestCase
                 PaytureOperation::PAY_STATUS(),
                 true,
             ],
+            'GetState' => [
+                '<GetState Success="True" OrderId="nw9z5rl8hkhhpfbb4ual7w" Amount="2000" State="Charged"
+                    RRN="003770024290"/>',
+                PaytureOperation::GET_STATE(),
+                true,
+            ],
         ];
     }
 
@@ -118,6 +124,11 @@ final class TerminalResponseBuilderTest extends TestCase
                 '<Charge Success="True" NewAmount="10000" />',
                 'getAmount',
                 10000,
+            ],
+            'RRN' => [
+                '<Charge Success="True" RRN="003770024290" />',
+                'getRrn',
+                '003770024290',
             ],
         ];
     }

--- a/tests/Unit/TerminalResponseBuilderTest.php
+++ b/tests/Unit/TerminalResponseBuilderTest.php
@@ -15,6 +15,10 @@ final class TerminalResponseBuilderTest extends TestCase
     /**
      * @dataProvider getValidResponseExamples
      *
+     * @param string $xml
+     * @param PaytureOperation $operation
+     * @param bool $success
+     *
      * @throws \Lamoda\Payture\InPayClient\Exception\InvalidResponseException
      */
     public function testBuilderParsesXmlStringIntoResponse(
@@ -81,6 +85,8 @@ final class TerminalResponseBuilderTest extends TestCase
     /**
      * @dataProvider getPopulatedFieldExamples
      *
+     * @param string $xml
+     * @param string $accessMethod
      * @param mixed $expectedValue
      *
      * @throws \Lamoda\Payture\InPayClient\Exception\InvalidResponseException

--- a/tests/Unit/TerminalResponseBuilderTest.php
+++ b/tests/Unit/TerminalResponseBuilderTest.php
@@ -15,10 +15,6 @@ final class TerminalResponseBuilderTest extends TestCase
     /**
      * @dataProvider getValidResponseExamples
      *
-     * @param string $xml
-     * @param PaytureOperation $operation
-     * @param bool $success
-     *
      * @throws \Lamoda\Payture\InPayClient\Exception\InvalidResponseException
      */
     public function testBuilderParsesXmlStringIntoResponse(
@@ -85,8 +81,6 @@ final class TerminalResponseBuilderTest extends TestCase
     /**
      * @dataProvider getPopulatedFieldExamples
      *
-     * @param string $xml
-     * @param string $accessMethod
      * @param mixed $expectedValue
      *
      * @throws \Lamoda\Payture\InPayClient\Exception\InvalidResponseException

--- a/tests/Unit/TerminalResponseTest.php
+++ b/tests/Unit/TerminalResponseTest.php
@@ -27,6 +27,10 @@ final class TerminalResponseTest extends TestCase
 
         $response->setErrorCode(TerminalResponse::ERROR_ILLEGAL_ORDER_STATE);
         self::assertEquals(TerminalResponse::ERROR_ILLEGAL_ORDER_STATE, $response->getErrorCode());
+
+        self::assertEquals(null, $response->getRrn());
+        $response->setRrn('003770024290');
+        self::assertEquals('003770024290', $response->getRrn());
     }
 
     public function testStateAccessors(): void


### PR DESCRIPTION
PayStatus method becomes obsolete. Please see https://payture.com/api/#inpay_paystatus_

Added GetState method and marked PayStatus as deprecated. Also added storing of RRN attribute from payture response.
Added and fixed tests.